### PR TITLE
Instantiate Writer properly in MultiplayerGame.cpp

### DIFF
--- a/Entities/MultiplayerGame.cpp
+++ b/Entities/MultiplayerGame.cpp
@@ -373,7 +373,10 @@ namespace RTE
 						}
 
 						if (saveSettings)
-							g_SettingsMan.Save(Writer("Base.rte/Settings.ini"));
+						{
+							Writer w("Base.rte/Settings.ini");
+							g_SettingsMan.Save(w);
+						}
 
 						m_pGUIController->EnableMouse(false);
 						m_Mode = CONNECTION;
@@ -437,7 +440,10 @@ namespace RTE
 						}
 
 						if (saveSettings)
-							g_SettingsMan.Save(Writer("Base.rte/Settings.ini"));
+						{
+							Writer w("Base.rte/Settings.ini");
+							g_SettingsMan.Save(w);
+						}
 
 						m_pGUIController->EnableMouse(false);
 						m_Mode = CONNECTION;


### PR DESCRIPTION
rvalues can only be used to initialize *const* lvalue references.