### PR TITLE
Fix the value checked for in RakNet

### DIFF
--- a/external/sources/RakNet/ReplicaManager3.cpp
+++ b/external/sources/RakNet/ReplicaManager3.cpp
@@ -138,7 +138,7 @@ void ReplicaManager3::AutoCreateConnectionList(
 {
 	for (unsigned int index=0; index < participantListIn.Size(); index++)
 	{
-		if (GetConnectionByGUID(participantListIn[index], worldId)==false)
+		if (GetConnectionByGUID(participantListIn[index], worldId) == nullptr)
 		{
 			Connection_RM3 *connection = AllocConnection(rakPeerInterface->GetSystemAddressFromGuid(participantListIn[index]), participantListIn[index]);
 			if (connection)


### PR DESCRIPTION
The return type of GetConnectionByGUID is a pointer